### PR TITLE
added minimal rails_helper to get specs green

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,5 @@
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
+# Prevent database truncation if the environment is production
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'rspec/rails'


### PR DESCRIPTION
Specs failing with

```
LoadError:
  cannot load such file -- rails_helper
# ./spec/routing/companies_routing_spec.rb:1:in `require'
# ./spec/routing/companies_routing_spec.rb:1:in `<top (required)>'
```

Adds a simple `rails_helper.rb` that includes rails files and rspec/rails gem.